### PR TITLE
Update rel cmd install path

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -29,7 +29,12 @@ brew install rel
 *Or, Install using go get:*
 
 ```bash
-go get github.com/go-rel/rel/cmd/rel
+go get github.com/go-rel/cmd/rel
+```
+
+*Since Go 1.18 use go install:*
+```bash
+go install github.com/go-rel/cmd/rel@latest
 ```
 
 *Verify installation:*


### PR DESCRIPTION
- Add notes for newer Go Version as go get is deprecated since 1.17
- Update path to rel migrate cmd since moved in another library